### PR TITLE
Update Localizable.strings (DE)

### DIFF
--- a/Framework/Resources/de.lproj/Localizable.strings
+++ b/Framework/Resources/de.lproj/Localizable.strings
@@ -2,25 +2,25 @@
 "Cancel" = "Abbrechen";
 
 /* Tooltip for non-empty shortcut button */
-"Click to record new shortcut" = "Klicken um neuen Kurzbefehl aufzunehmen";
+"Click to record new shortcut" = "Klicken um neuen Tastaturkurzbefehl aufzunehmen";
 
 /* Tooltip for hint button near the non-empty shortcut */
-"Delete shortcut" = "Kurzbefehl Löschen";
+"Delete shortcut" = "Tastaturkurzbefehl löschen";
 
 /* VoiceOver title */
-"keyboard shortcut" = "Kurzbefehl";
+"keyboard shortcut" = "Tastaturkurzbefehl";
 
 /* Alert button when shortcut is already used */
 "OK" = "OK";
 
 /* Empty shortcut button in normal state */
-"Record Shortcut" = "Kurzbefehl aufnehmen";
+"Record Shortcut" = "Tastaturkurzbefehl aufnehmen";
 
 /* VoiceOver: Shortcut cleared */
-"Shortcut cleared" = "Kurzbefehl gelöscht";
+"Shortcut cleared" = "Tastaturkurzbefehl gelöscht";
 
 /* VoiceOver: Shortcut set */
-"Shortcut set" = "Kurzbefehl gesetzt";
+"Shortcut set" = "Tastaturkurzbefehl gesetzt";
 
 /* Shortcut glyph name for SPACE key */
 "Space" = "Leertaste";
@@ -29,19 +29,19 @@
 "The key combination %@ cannot be used" = "Die Tastenkombination %@ kann nicht genutzt werden";
 
 /* Message for alert when shortcut is already used by the system */
-"This combination cannot be used because it is already used by a system-wide keyboard shortcut.\nIf you really want to use this key combination, most shortcuts can be changed in the Keyboard & Mouse panel in System Preferences." = "Diese Kombination kann nicht genutzt werden, weil sie bereits als systemweiter Kurzbefehl genutzt wird.\nFalls du diese Tastenkombination wirklich benutzen willst, können die meisten Kurzbefehle in den Tastatur Systemeinstellungen geändert werden.";
+"This combination cannot be used because it is already used by a system-wide keyboard shortcut.\nIf you really want to use this key combination, most shortcuts can be changed in the Keyboard & Mouse panel in System Preferences." = "Diese Kombination kann nicht genutzt werden, da sie bereits als systemweiter Tastaturkurzbefehl genutzt wird.\nFalls du diese Tastenkombination wirklich benutzen willst, können die meisten Kurzbefehle in Systemeinstellungen > Tastatur geändert werden.";
 
 /* Message for alert when shortcut is already used */
-"This shortcut cannot be used because it is already used by the menu item ‘%@’." = "Dieser Kurzbefehl kann nicht genutzt werden, weil er bereits vom Menüpunkt „%@“ genutzt wird.";
+"This shortcut cannot be used because it is already used by the menu item ‘%@’." = "Dieser Tastaturkurzbefehl kann nicht genutzt werden, da er bereits vom Menüpunkt „%@“ genutzt wird.";
 
 /* VoiceOver shortcut help */
-"To record a new shortcut, click this button, and then type the new shortcut, or press delete to clear an existing shortcut." = "Drücke diesen Button, um einen neuen Kurzbefehl aufzunehmen. Tippe dann den neuen Kurzbefehl oder drücke Löschen, um den aktuellen Kurzbefehl zu löschen.";
+"To record a new shortcut, click this button, and then type the new shortcut, or press delete to clear an existing shortcut." = "Drücke diesen Button, um einen neuen Tastaturkurzbefehl aufzunehmen. Tippe dann den neuen Tastaturkurzbefehl oder drücke Löschen, um den aktuellen Tastaturkurzbefehl zu löschen.";
 
 /* Non-empty shortcut button in recording state */
-"Type New Shortcut" = "Neuen eingeben";
+"Type New Shortcut" = "Neuen Tastaturkurzbefehl eingeben";
 
 /* Empty shortcut button in recording state */
-"Type Shortcut" = "Kurzbefehl eingeben";
+"Type Shortcut" = "Tastaturkurzbefehl eingeben";
 
 /* Cancel action button for non-empty shortcut in recording state */
-"Use Old Shortcut" = "Alten nutzen";
+"Use Old Shortcut" = "Alten Tastaturkurzbefehl nutzen";


### PR DESCRIPTION
Minor wording changes made to be consistent with the naming of keyboard shortcuts in macOS (see https://support.apple.com/de-de/102650).

This change is also proposed to avoid confusion of the term shortcut (which is now more associated with customizable actions in the Shortcuts.app).

This change from “Kurzbefehl” (shortcut) to “Tastaturkurzbefehl” (keyboard shortcut) slightly increases the length of the translation.